### PR TITLE
Add constant logic checks (PB804 and PB805)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ If using without Pants, run `flake8 your_module.py` [as usual](http://flake8.pyc
 
 ## Error Codes
 
-| Error code | Description                            |
-|:----------:|:--------------------------------------:|
-| PB800      | Found bad reference to class attribute |
+| Error code | Description                                                  |
+|:----------:|:------------------------------------------------------------:|
+| PB800      | Found bad reference to class attribute                       |
+| PB804      | Using a constant on the left-hand side of a logical operator |
+| PB805      | Using a constant on the right-hand side of an and operator   |
 
 ## Migration from `pantsbuild.pants.contrib.python.checks.checker`
 

--- a/flake8_pantsbuild.py
+++ b/flake8_pantsbuild.py
@@ -31,11 +31,11 @@ class Visitor(ast.NodeVisitor):
     def visit_BoolOp(self, bool_op_node):
         def is_constant(expr):
             if PY2:
-                is_name_constant = isinstance(expr, ast.Name) and expr.id in [
+                is_name_constant = isinstance(expr, ast.Name) and expr.id in (
                     "True",
                     "False",
                     "None",
-                ]
+                )
             else:
                 is_name_constant = isinstance(expr, ast.NameConstant)
             return isinstance(expr, (ast.Num, ast.Str)) or is_name_constant

--- a/flake8_pantsbuild.py
+++ b/flake8_pantsbuild.py
@@ -12,11 +12,14 @@ if sys.version_info >= (3, 8):
 else:
     from importlib_metadata import version
 
+PY2 = sys.version_info[0] < 3
 
 PB800 = (
     "PB800 Instead of {name}.{attr} use self.{attr} or cls.{attr} with instance methods and "
     "classmethods, respectively."
 )
+PB804 = "PB804 using a constant on the left-hand side of a logical operator."
+PB805 = "PB805 using a constant on the right-hand side of an `and` operator."
 
 
 class Visitor(ast.NodeVisitor):
@@ -24,6 +27,26 @@ class Visitor(ast.NodeVisitor):
 
     def __init__(self):
         self.errors = []
+
+    def visit_BoolOp(self, bool_op_node):
+        def is_constant(expr):
+            if PY2:
+                is_name_constant = isinstance(expr, ast.Name) and expr.id in [
+                    "True",
+                    "False",
+                    "None",
+                ]
+            else:
+                is_name_constant = isinstance(expr, ast.NameConstant)
+            return isinstance(expr, (ast.Num, ast.Str)) or is_name_constant
+
+        if isinstance(bool_op_node.op, (ast.And, ast.Or)):
+            leftmost = bool_op_node.values[0]
+            rightmost = bool_op_node.values[-1]
+            if is_constant(leftmost):
+                self.errors.append((leftmost.lineno, leftmost.col_offset, PB804))
+            if isinstance(bool_op_node.op, ast.And) and is_constant(rightmost):
+                self.errors.append((rightmost.lineno, rightmost.col_offset, PB805))
 
     def visit_ClassDef(self, class_node):
         for node in ast.walk(class_node):


### PR DESCRIPTION
These check for likely issues in boolean expressions. Using constants in a boolean expression means that the conditional will short-circuit, which is likely a bug.

MyPy does have some checking for this already, but MyPy does not complain about using truthy strings and numbers nor do we want to require users to start using MyPy to get the benefits of this lint.