### PR TITLE
Add check for missing context manager with `open()` (PB802)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 /dist/
 /flake8_pantsbuild.egg-info/
+/poetry.lock
 
 /.tox/
 /.pytest_cache

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ If using without Pants, run `flake8 your_module.py` [as usual](http://flake8.pyc
 | Error code | Description                                                  |
 |:----------:|:------------------------------------------------------------:|
 | PB800      | Found bad reference to class attribute                       |
+| PB802      | Using `open` without a `with` statement (context manager)    |
 | PB804      | Using a constant on the left-hand side of a logical operator |
 | PB805      | Using a constant on the right-hand side of an and operator   |
 

--- a/flake8_pantsbuild_test.py
+++ b/flake8_pantsbuild_test.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import itertools
 from textwrap import dedent
 
-from flake8_pantsbuild import PB800, PB804, PB805
+from flake8_pantsbuild import PB800, PB802, PB804, PB805
 
 # NB: `pytest-flake8dir` has a known issue that it runs our plugin twice for every test. This means
 # that result.out will have the same error twice for every file. This was fixed in 2.1.0, but we
@@ -31,6 +31,33 @@ def test_pb_800(flake8dir):
     flake8dir.make_py_files(good=template.format("self"), bad=template.format("Example"))
     result = flake8dir.run_flake8()
     assert {"./bad.py:8:29: {}".format(PB800.format(name="Example", attr="CONSTANT"))} == set(
+        result.out_lines
+    )
+
+
+def test_pb_802(flake8dir):
+    good = dedent(
+        """\
+        with open('test.txt'):
+            pass
+
+        with open('test.txt') as fp:
+            fp.read()
+        """
+    )
+    bad = dedent(
+        """\
+        foo = open('test.txt')
+
+        with open('test.txt'):
+            pass
+
+        bar = open('test.txt')
+        """
+    )
+    flake8dir.make_py_files(good=good, bad=bad)
+    result = flake8dir.run_flake8()
+    assert {"./bad.py:1:7: {}".format(PB802), "./bad.py:6:7: {}".format(PB802)} == set(
         result.out_lines
     )
 

--- a/flake8_pantsbuild_test.py
+++ b/flake8_pantsbuild_test.py
@@ -36,28 +36,23 @@ def test_pb_800(flake8dir):
 
 
 def test_pb_802(flake8dir):
-    good = dedent(
-        """\
-        with open('test.txt'):
-            pass
+    flake8dir.make_example_py(
+        dedent(
+            """\
+            foo = open('test.txt')
 
-        with open('test.txt') as fp:
-            fp.read()
-        """
+            with open('test.txt'):
+                pass
+
+            bar = open('test.txt')
+
+            with open('test.txt') as fp:
+                fp.read()
+            """
+        )
     )
-    bad = dedent(
-        """\
-        foo = open('test.txt')
-
-        with open('test.txt'):
-            pass
-
-        bar = open('test.txt')
-        """
-    )
-    flake8dir.make_py_files(good=good, bad=bad)
     result = flake8dir.run_flake8()
-    assert {"./bad.py:1:7: {}".format(PB802), "./bad.py:6:7: {}".format(PB802)} == set(
+    assert {"./example.py:1:7: {}".format(PB802), "./example.py:6:7: {}".format(PB802)} == set(
         result.out_lines
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     pytest==4.6.6
     pytest-flake8dir==1.3.0
 commands =
-    pytest {posargs}
+    pytest -v {posargs}
     # NB: Flake8 results depend upon which Python version is used. We want it to run for every
     # Python version to ensure that we are correctly handing the AST.
     flake8 .


### PR DESCRIPTION
There is no alternative available on PyPI for this one.