### PR TITLE
Refactor to make it more clear what code the logic corresponds to

### DIFF
--- a/flake8_pantsbuild.py
+++ b/flake8_pantsbuild.py
@@ -28,9 +28,47 @@ class Visitor(ast.NodeVisitor):
 
     def __init__(self):
         self.errors = []
-        self.with_context_exprs = set()
+        self.with_call_exprs = set()
 
-    def visit_BoolOp(self, bool_op_node):
+    def collect_call_exprs_from_with_node(self, with_node):
+        """Save any functions within a `with` statement to `self.with_call_exprs`.
+
+        This is needed for checking PB802.
+        """
+        if PY2:
+            expr = with_node.context_expr
+            with_context_exprs = {expr} if isinstance(expr, ast.Call) else set()
+        else:
+            with_context_exprs = {
+                node.context_expr
+                for node in with_node.items
+                if isinstance(node.context_expr, ast.Call)
+            }
+        self.with_call_exprs.update(with_context_exprs)
+
+    def check_for_pb800(self, class_def_node):
+        for node in ast.walk(class_def_node):
+            is_class_attribute = isinstance(node, ast.Attribute) and isinstance(
+                node.value, ast.Name
+            )
+            if is_class_attribute and node.value.id == class_def_node.name:
+                self.errors.append(
+                    (
+                        node.value.lineno,
+                        node.value.col_offset,
+                        PB800.format(name=class_def_node.name, attr=node.attr),
+                    )
+                )
+
+    def check_for_pb802(self, call_node):
+        if (
+            isinstance(call_node.func, ast.Name)
+            and call_node.func.id == "open"
+            and call_node not in self.with_call_exprs
+        ):
+            self.errors.append((call_node.lineno, call_node.col_offset, PB802))
+
+    def check_for_pb804_and_pb805(self, bool_op_node):
         def is_constant(expr):
             if PY2:
                 is_name_constant = isinstance(expr, ast.Name) and expr.id in (
@@ -42,47 +80,26 @@ class Visitor(ast.NodeVisitor):
                 is_name_constant = isinstance(expr, ast.NameConstant)
             return isinstance(expr, (ast.Num, ast.Str)) or is_name_constant
 
-        if isinstance(bool_op_node.op, (ast.And, ast.Or)):
-            leftmost = bool_op_node.values[0]
-            rightmost = bool_op_node.values[-1]
-            if is_constant(leftmost):
-                self.errors.append((leftmost.lineno, leftmost.col_offset, PB804))
-            if isinstance(bool_op_node.op, ast.And) and is_constant(rightmost):
-                self.errors.append((rightmost.lineno, rightmost.col_offset, PB805))
+        if not isinstance(bool_op_node.op, (ast.And, ast.Or)):
+            return
+        leftmost = bool_op_node.values[0]
+        rightmost = bool_op_node.values[-1]
+        if is_constant(leftmost):
+            self.errors.append((leftmost.lineno, leftmost.col_offset, PB804))
+        if isinstance(bool_op_node.op, ast.And) and is_constant(rightmost):
+            self.errors.append((rightmost.lineno, rightmost.col_offset, PB805))
 
-    def visit_ClassDef(self, class_node):
-        for node in ast.walk(class_node):
-            is_class_attribute = isinstance(node, ast.Attribute) and isinstance(
-                node.value, ast.Name
-            )
-            if is_class_attribute and node.value.id == class_node.name:
-                self.errors.append(
-                    (
-                        node.value.lineno,
-                        node.value.col_offset,
-                        PB800.format(name=class_node.name, attr=node.attr),
-                    )
-                )
-
-    def visit_With(self, with_node):
-        if PY2:
-            expr = with_node.context_expr
-            with_context_exprs = {expr} if isinstance(expr, ast.Call) else set()
-        else:
-            with_context_exprs = {
-                node.context_expr
-                for node in with_node.items
-                if isinstance(node.context_expr, ast.Call)
-            }
-        self.with_context_exprs.update(with_context_exprs)
+    def visit_BoolOp(self, bool_op_node):
+        self.check_for_pb804_and_pb805(bool_op_node)
 
     def visit_Call(self, call_node):
-        if (
-            isinstance(call_node.func, ast.Name)
-            and call_node.func.id == "open"
-            and call_node not in self.with_context_exprs
-        ):
-            self.errors.append((call_node.lineno, call_node.col_offset, PB802))
+        self.check_for_pb802(call_node)
+
+    def visit_ClassDef(self, class_def_node):
+        self.check_for_pb800(class_def_node)
+
+    def visit_With(self, with_node):
+        self.collect_call_exprs_from_with_node(with_node)
 
 
 class Plugin(object):


### PR DESCRIPTION
We need to add at least 5 new lints to be able to remove python-checkstyle. 

It was getting confusing to see what code corresponded to which check. This refactor of using helper methods is meant to make this more clear.