### PR TITLE
Add PB602, PB603, and PB604 to check for Python 2-only symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,19 @@ If using without Pants, run `flake8 your_module.py` [as usual](http://flake8.pyc
 
 ## Error Codes
 
-| Error code | Description                                                     |
-|:----------:|:---------------------------------------------------------------:|
-| PB601      | Using old style `except` statements instead of the `as` keyword |
-| PB605      | Using metaclasses incompatible with Python 3                    |
-| PB606      | Found Python 2 old-style classes (not inheriting `object`)      |
-| PB607      | Using print statements, rather than print functions             |
-| PB800      | Found bad reference to class attribute                          |
-| PB802      | Using `open` without a `with` statement (context manager)       |
-| PB804      | Using a constant on the left-hand side of a logical operator    |
-| PB805      | Using a constant on the right-hand side of an and operator      |
+| Error code | Description                                                          |
+|:----------:|:--------------------------------------------------------------------:|
+| PB601      | Using old style `except` statements instead of the `as` keyword      |
+| PB602      | Using `iteritems`, `iterkeys`, or `itervalues` (removed in Python 3) |
+| PB603      | Using `xrange` (removed in Python 3)                                 |
+| PB604      | Using `basestring` or `unicode` (removed in Python 3)                |
+| PB605      | Using metaclasses incompatible with Python 3                         |
+| PB606      | Found Python 2 old-style classes (not inheriting `object`)           |
+| PB607      | Using print statements, rather than print functions                  |
+| PB800      | Found bad reference to class attribute                               |
+| PB802      | Using `open` without a `with` statement (context manager)            |
+| PB804      | Using a constant on the left-hand side of a logical operator         |
+| PB805      | Using a constant on the right-hand side of an and operator           |
 
 ## Migration from `pantsbuild.pants.contrib.python.checks.checker`
 


### PR DESCRIPTION
This also fixes a bug where we stopped traversing the AST after the top-level nodes. For example, with `assert isinstance("hello", str)`, we would never traverse to the `ast.Name` node associated with `str`.