### PR TITLE
Disable Python 2->3 lints by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ This Flake8 plugin provides several custom lints used by the Pants project and i
 
 ## Installation
 
-If using with Pants, add this to your `pants.ini`:
+If using with Pants, add this to your `pants.toml`:
 
-```ini
+```toml
 [GLOBAL]
-backend_packages2: +['pants.backend.python.lint.flake8']
+backend_packages2.add = ["pants.backend.python.lint.flake8"]
 
 [flake8]
-extra_requirements: +['flake8-pantsbuild']
+extra_requirements.add = ["flake8-pantsbuild"]
 ```
 
 If using Flake8 without Pants, install with:
@@ -22,25 +22,27 @@ $ pip install flake8-pantsbuild
 
 ## Usage
 
-If using with Pants, run `./pants lint2 ::` as usual.
+If using with Pants, run `./pants lint file.py` as usual.
 
-If using without Pants, run `flake8 your_module.py` [as usual](http://flake8.pycqa.org/en/latest/user/invocation.html).
+If using without Pants, run `flake8 file.py` [as usual](http://flake8.pycqa.org/en/latest/user/invocation.html).
 
 ## Error Codes
 
-| Error code | Description                                                          |
-|:----------:|:--------------------------------------------------------------------:|
-| PB601      | Using old style `except` statements instead of the `as` keyword      |
-| PB602      | Using `iteritems`, `iterkeys`, or `itervalues` (removed in Python 3) |
-| PB603      | Using `xrange` (removed in Python 3)                                 |
-| PB604      | Using `basestring` or `unicode` (removed in Python 3)                |
-| PB605      | Using metaclasses incompatible with Python 3                         |
-| PB606      | Found Python 2 old-style classes (not inheriting `object`)           |
-| PB607      | Using print statements, rather than print functions                  |
-| PB800      | Found bad reference to class attribute                               |
-| PB802      | Using `open` without a `with` statement (context manager)            |
-| PB804      | Using a constant on the left-hand side of a logical operator         |
-| PB805      | Using a constant on the right-hand side of an and operator           |
+| Error code | Description                                                     | Notes                |
+|:----------:|:---------------------------------------------------------------:|:--------------------:|
+| PB601      | Using old style `except` statements instead of the `as` keyword | Disabled by default¹ |
+| PB602      | Using `iteritems`, `iterkeys`, or `itervalues`                  | Disabled by default¹ |
+| PB603      | Using `xrange`                                                  | Disabled by default¹ |
+| PB604      | Using `basestring` or `unicode`                                 | Disabled by default¹ |
+| PB605      | Using metaclasses incompatible with Python 3                    | Disabled by default¹ |
+| PB606      | Found Python 2 old-style classes (not inheriting `object`)      | Disabled by default¹ |
+| PB607      | Using print statements, rather than print functions             | Disabled by default¹ |
+| PB800      | Used class attribute that breaks inheritance                    |                      |
+| PB802      | Using `open` without a `with` statement (context manager)       |                      |
+| PB804      | Using a constant on the left-hand side of a logical operator    |                      |
+| PB805      | Using a constant on the right-hand side of an and operator      |                      |
+
+¹ To enable the `PB6*` checks for Python 2->3 lints, set `--enable-extensions PB6`. 
 
 ## Migration from `pantsbuild.pants.contrib.python.checks.checker`
 

--- a/flake8_pantsbuild.py
+++ b/flake8_pantsbuild.py
@@ -38,7 +38,7 @@ PB607 = (
 )
 PB800 = (
     "PB800 Instead of {name}.{attr} use self.{attr} or cls.{attr} with instance methods and "
-    "classmethods, respectively."
+    "classmethods, respectively, so that inheritance works correctly."
 )
 PB802 = "PB802 `open()` calls should be made within a `with` statement (context manager)"
 PB804 = "PB804 Using a constant on the left-hand side of a logical operator."
@@ -226,3 +226,9 @@ class Plugin(object):
         visitor.visit(self._tree)
         for line, col, msg in visitor.errors:
             yield line, col, msg, type(self)
+
+
+class SixPlugin(Plugin):
+    """Several lints to help with Python 2->3 migrations."""
+
+    off_by_default = True

--- a/flake8_pantsbuild_test.py
+++ b/flake8_pantsbuild_test.py
@@ -62,7 +62,7 @@ def test_pb_601(flake8dir):
             """
         )
     )
-    result = flake8dir.run_flake8()
+    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
     assert {"./example.py:3:1: {}".format(PB601), "./example.py:8:1: {}".format(PB601)} == set(
         result.out_lines
     )
@@ -96,7 +96,7 @@ def test_pb_602(flake8dir):
             """
         )
     )
-    result = flake8dir.run_flake8()
+    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
     assert {
         "./example.py:7:1: {}".format(PB602.format(bad_attr="iteritems", good_attr="items")),
         "./example.py:8:1: {}".format(PB602.format(bad_attr="iterkeys", good_attr="keys")),
@@ -123,7 +123,7 @@ def test_pb_603(flake8dir):
             """
         )
     )
-    result = flake8dir.run_flake8()
+    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
     assert {"./example.py:4:1: {}".format(PB603)} == set(result.out_lines)
 
 
@@ -137,7 +137,7 @@ def test_pb_604(flake8dir):
             """
         )
     )
-    result = flake8dir.run_flake8()
+    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
     assert {
         "./example.py:1:26: {}".format(
             PB604.format(bad_name="unicode", six_replacement="text_type")
@@ -170,7 +170,7 @@ def test_pb_605(flake8dir):
             """
         )
     )
-    result = flake8dir.run_flake8()
+    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
     assert {"./example.py:6:5: {}".format(PB605)} == set(result.out_lines)
 
 
@@ -198,7 +198,7 @@ def test_pb_606(flake8dir):
             """
         )
     )
-    result = flake8dir.run_flake8()
+    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
     assert {"./example.py:4:1: {}".format(PB606), "./example.py:16:1: {}".format(PB606)} == set(
         result.out_lines
     )
@@ -227,7 +227,7 @@ def test_pb_607(flake8dir):
             """
         ),
     )
-    result = flake8dir.run_flake8()
+    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
     assert {"./normal.py:7:1: {}".format(PB607), "./normal.py:8:1: {}".format(PB607)} == set(
         result.out_lines
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = ["Pantsbuild developers <pantsbuild@gmail.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.plugins."flake8.extension"]
-PB = "flake8_pantsbuild:Plugin"
+PB8 = "flake8_pantsbuild:Plugin"
+PB6 = "flake8_pantsbuild:SixPlugin"
 
 [tool.poetry.dependencies]
 python = ">=2.7,<3.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"


### PR DESCRIPTION
Now that Python 2 is EOL, Pants assumes that Python codebases are using Python 3. They can still use Python 2, but the user must opt-in to Python 2 support.

The author of Flake8 suggested a very nice design pattern in https://gitlab.com/pycqa/flake8/-/issues/482 to have an optional plugin as a part of the core distribution. All that users need to do is set `--enable-extensions PB6` to turn on this entire set of lints.

Once we add the formatting lints, like checking for 2-space indentation, we will be able to use this same pattern to have a FormattingPlugin, which is disabled by default.