### PR TITLE
Add PB201 to check for trailing slash for line continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,23 @@ If using without Pants, run `flake8 file.py` [as usual](http://flake8.pycqa.org/
 | Error code | Description                                                     | Notes                |
 |:----------:|:---------------------------------------------------------------:|:--------------------:|
 | PB100      | Check for 2-space indentation                                   | Disabled by default¹ |
-| PB601      | Using old style `except` statements instead of the `as` keyword | Disabled by default² |
-| PB602      | Using `iteritems`, `iterkeys`, or `itervalues`                  | Disabled by default² |
-| PB603      | Using `xrange`                                                  | Disabled by default² |
-| PB604      | Using `basestring` or `unicode`                                 | Disabled by default² |
-| PB605      | Using metaclasses incompatible with Python 3                    | Disabled by default² |
-| PB606      | Found Python 2 old-style classes (not inheriting `object`)      | Disabled by default² |
-| PB607      | Using print statements, rather than print functions             | Disabled by default² |
+| PB200      | Check for trailing whitespace                                   | Disabled by default² |
+| PB201      | Check for trailing slashes (`\`)                                | Disabled by default² |
+| PB601      | Using old style `except` statements instead of the `as` keyword | Disabled by default³ |
+| PB602      | Using `iteritems`, `iterkeys`, or `itervalues`                  | Disabled by default³ |
+| PB603      | Using `xrange`                                                  | Disabled by default³ |
+| PB604      | Using `basestring` or `unicode`                                 | Disabled by default³ |
+| PB605      | Using metaclasses incompatible with Python 3                    | Disabled by default³ |
+| PB606      | Found Python 2 old-style classes (not inheriting `object`)      | Disabled by default³ |
+| PB607      | Using print statements, rather than print functions             | Disabled by default³ |
 | PB800      | Used class attribute that breaks inheritance                    |                      |
 | PB802      | Using `open` without a `with` statement (context manager)       |                      |
 | PB804      | Using a constant on the left-hand side of a logical operator    |                      |
 | PB805      | Using a constant on the right-hand side of an and operator      |                      |
 
-¹ To enable the `PB100` indentation lint, set `--enable-extensions PB100`. You'll need to disable `E111` (check for 4-space indentation) via `--extend-ignore=E111`. You'll likely want to disable `E121`, `E124`, `E125`, `E127`, and `E128` as well.
-² To enable the `PB6*` checks for Python 2->3 lints, set `--enable-extensions PB6`. 
+¹ To enable the `PB100` indentation lint, set `--enable-extensions=PB100`. You'll need to disable `E111` (check for 4-space indentation) via `--extend-ignore=E111`. You'll likely want to disable `E121`, `E124`, `E125`, `E127`, and `E128` as well.
+² To enable the `PB2*` trailing whitespace lints, set `--enable-extensions=PB2`. You'll need to disable `W291` and `W293`, which are stricter versions of the `PB2*` lints, via `--extend-ignore=W291,W293`.
+³ To enable the `PB6*` checks for Python 2->3 lints, set `--enable-extensions=PB6`. 
 
 ## Migration from `pantsbuild.pants.contrib.python.checks.checker`
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ If using without Pants, run `flake8 file.py` [as usual](http://flake8.pycqa.org/
 | Error code | Description                                                     | Notes                |
 |:----------:|:---------------------------------------------------------------:|:--------------------:|
 | PB100      | Check for 2-space indentation                                   | Disabled by default¹ |
-| PB200      | Check for trailing whitespace                                   | Disabled by default² |
 | PB201      | Check for trailing slashes (`\`)                                | Disabled by default² |
 | PB601      | Using old style `except` statements instead of the `as` keyword | Disabled by default³ |
 | PB602      | Using `iteritems`, `iterkeys`, or `itervalues`                  | Disabled by default³ |
@@ -46,7 +45,7 @@ If using without Pants, run `flake8 file.py` [as usual](http://flake8.pycqa.org/
 | PB805      | Using a constant on the right-hand side of an and operator      |                      |
 
 ¹ To enable the `PB100` indentation lint, set `--enable-extensions=PB100`. You'll need to disable `E111` (check for 4-space indentation) via `--extend-ignore=E111`. You'll likely want to disable `E121`, `E124`, `E125`, `E127`, and `E128` as well.
-² To enable the `PB2*` trailing whitespace lints, set `--enable-extensions=PB2`. You'll need to disable `W291` and `W293`, which are stricter versions of the `PB2*` lints, via `--extend-ignore=W291,W293`.
+² To enable the `PB201` trailing slash lint, set `--enable-extensions=PB201`.
 ³ To enable the `PB6*` checks for Python 2->3 lints, set `--enable-extensions=PB6`. 
 
 ## Migration from `pantsbuild.pants.contrib.python.checks.checker`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If using without Pants, run `flake8 file.py` [as usual](http://flake8.pycqa.org/
 | Error code | Description                                                     | Notes                |
 |:----------:|:---------------------------------------------------------------:|:--------------------:|
 | PB100      | Check for 2-space indentation                                   | Disabled by default¹ |
-| PB201      | Check for trailing slashes (`\`)                                | Disabled by default² |
+| PB201      | Using slashes instead of parentheses for line continuation      | Disabled by default² |
 | PB601      | Using old style `except` statements instead of the `as` keyword | Disabled by default³ |
 | PB602      | Using `iteritems`, `iterkeys`, or `itervalues`                  | Disabled by default³ |
 | PB603      | Using `xrange`                                                  | Disabled by default³ |

--- a/flake8_pantsbuild.py
+++ b/flake8_pantsbuild.py
@@ -19,7 +19,7 @@ PY2 = sys.version_info[0] < 3
 
 PB100 = "PB100 Indentation of {} instead of 2."
 PB201 = (
-    "PB201 Line has trailing slashes (`\\`). Instead, use parentheses to wrap the line. Refer "
+    "PB201 Using a trailing slash (`\\`) instead of parentheses for line continuation. Refer "
     "to https://www.tutorialspoint.com/How-to-wrap-long-lines-in-Python."
 )
 PB601 = (

--- a/flake8_pantsbuild.py
+++ b/flake8_pantsbuild.py
@@ -8,6 +8,7 @@ import ast
 import re
 import sys
 import tokenize
+from collections import defaultdict
 
 if sys.version_info >= (3, 8):
     from importlib.metadata import version
@@ -17,6 +18,11 @@ else:
 PY2 = sys.version_info[0] < 3
 
 PB100 = "PB100 Indentation of {} instead of 2."
+PB200 = "PB200 Line has trailing whitespace."
+PB201 = (
+    "PB201 Line has trailing slashes (`\\`). Instead, use parentheses to wrap the line. Refer "
+    "to https://www.tutorialspoint.com/How-to-wrap-long-lines-in-Python."
+)
 PB601 = (
     "PB601 Using an old-style except statement. Instead of `except ValueError, e`, use "
     "`except ValueError as e`."
@@ -42,9 +48,19 @@ PB800 = (
     "PB800 Instead of {name}.{attr} use self.{attr} or cls.{attr} with instance methods and "
     "classmethods, respectively, so that inheritance works correctly."
 )
-PB802 = "PB802 `open()` calls should be made within a `with` statement (context manager)"
-PB804 = "PB804 Using a constant on the left-hand side of a logical operator."
-PB805 = "PB805 Using a constant on the right-hand side of an `and` operator."
+PB802 = (
+    "PB802 `open()` calls should be made within a `with` statement (context manager). This is "
+    "important to ensure that the file handler is properly cleaned up."
+)
+PB804 = (
+    "PB804 Using a constant on the left-hand side of a logical operator. This means that the "
+    "left-hand side will always be truthy, so condition will short-circuit and the right-hand side "
+    "will never be evaluated."
+)
+PB805 = (
+    "PB805 Using a constant on the right-hand side of an `and` operator. This means that the "
+    "right-hand side will always be truthy, which is likely not expected."
+)
 
 
 class Visitor(ast.NodeVisitor):
@@ -57,6 +73,7 @@ class Visitor(ast.NodeVisitor):
         self.errors = []
         self.with_call_exprs = set()
         self.check_for_pb100(tokens)
+        self.check_for_pb200_and_pb201(lines=lines, tokens=tokens)
 
     def collect_call_exprs_from_with_node(self, with_node):
         """Save any functions within a `with` statement to `self.with_call_exprs`.
@@ -75,8 +92,6 @@ class Visitor(ast.NodeVisitor):
         self.with_call_exprs.update(with_context_exprs)
 
     def check_for_pb100(self, tokens):
-        # NB: This implementation is different. Rather than being AST-based, this is token-based,
-        # so we don't use the AST Visitor pattern.
         indents = []
         for token in tokens:
             token_type, token_text, token_start = token[0:3]
@@ -91,6 +106,47 @@ class Visitor(ast.NodeVisitor):
                     self.errors.append(
                         (lineno, col_offset, PB100.format(current_indent - last_indent))
                     )
+
+    def check_for_pb200_and_pb201(self, lines, tokens):
+        lines = [line.rstrip("\n") for line in lines]
+        # First generate a set of ranges where we accept trailing slashes and whitespace,
+        # specifically within comments and strings
+        exception_map = defaultdict(list)
+        for token in tokens:
+            token_type, _, token_start, token_end = token[0:4]
+            if token_type not in (tokenize.COMMENT, tokenize.STRING):
+                continue
+            token_start_line, token_start_col_offset = token_start
+            token_end_line, token_end_col_offset = token_end
+            if token_start_line == token_end_line:
+                exception_map[token_start_line].append(
+                    (token_start_col_offset, token_end_col_offset)
+                )
+            else:
+                exception_map[token_start_line].append((token_start_col_offset, sys.maxsize))
+                for line in range(token_start_line + 1, token_end_line):
+                    exception_map[line].append((0, sys.maxsize))
+                exception_map[token_end_line].append((0, token_end_col_offset))
+
+        def has_exception(lineno, exception_start, exception_end=None):
+            exception_end = exception_end or exception_start
+            for start, end in exception_map.get(lineno, []):
+                if exception_start >= start and exception_end <= end:
+                    return True
+            return False
+
+        for line_number, line in enumerate(lines):
+            # Tokens are 1-indexed, rather than 0-indexed.
+            line_number += 1
+            stripped_line = line.rstrip()
+            if stripped_line != line and not has_exception(
+                line_number, len(stripped_line), len(line)
+            ):
+                self.errors.append((line_number, len(stripped_line), PB200))
+            if stripped_line.endswith("\\") and not has_exception(
+                line_number, len(stripped_line) - 1
+            ):
+                self.errors.append((line_number, len(stripped_line) - 1, PB201))
 
     def check_for_pb601(self, try_except_node):
         for handler in try_except_node.handlers:
@@ -261,6 +317,19 @@ class IndentationPlugin(Plugin):
 
     This is disabled by default because it conflicts with Flake8's default settings of 4-space
     indentation.
+    """
+
+    off_by_default = True
+
+
+class TrailingWhitespacePlugin(Plugin):
+    """Check for trailing whitespace and slashes.
+
+    Flake8 already has lints for trailing whitespace, but the custom lints are more permissive,
+    such as allowing for whitespace in comments.
+
+    Flake8 does not automatically check for trailing slashes, but this is a subjective style
+    preference so should be disabled by default.
     """
 
     off_by_default = True

--- a/flake8_pantsbuild_test.py
+++ b/flake8_pantsbuild_test.py
@@ -11,7 +11,6 @@ import pytest
 
 from flake8_pantsbuild import (
     PB100,
-    PB200,
     PB201,
     PB601,
     PB602,
@@ -66,32 +65,6 @@ def test_pb_100(flake8dir):
     } == set(result.out_lines)
 
 
-def test_pb_200(flake8dir):
-    # NB: we use `.format()` to inject whitespace to ensure that IDEs don't remove it.
-    flake8dir.make_example_py(
-        dedent(
-            """\
-            b1 = "hello"{s}
-            b2 = (
-                "hi"{s}
-                "there!"
-            )
-
-            g1 = "I love space...             "
-            # comments get a free pass{s}{s}{s}
-            """.format(
-                s=" "
-            )
-        )
-    )
-    result = flake8dir.run_flake8(
-        extra_args=["--enable-extensions", "PB2", "--extend-ignore", "W291"]
-    )
-    assert {"./example.py:1:13: {}".format(PB200), "./example.py:3:9: {}".format(PB200)} == set(
-        result.out_lines
-    )
-
-
 def test_pb_201(flake8dir):
     flake8dir.make_example_py(
         dedent(
@@ -120,7 +93,7 @@ def test_pb_201(flake8dir):
             """
         )
     )
-    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB2"])
+    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB201"])
     assert {"./example.py:3:7: {}".format(PB201), "./example.py:6:20: {}".format(PB201)} == set(
         result.out_lines
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 [tool.poetry.plugins."flake8.extension"]
 PB8 = "flake8_pantsbuild:Plugin"
 PB100 = "flake8_pantsbuild:IndentationPlugin"
-PB2 = "flake8_pantsbuild:TrailingWhitespacePlugin"
+PB201 = "flake8_pantsbuild:TrailingSlashesPlugin"
 PB6 = "flake8_pantsbuild:SixPlugin"
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = "Apache-2.0"
 [tool.poetry.plugins."flake8.extension"]
 PB8 = "flake8_pantsbuild:Plugin"
 PB100 = "flake8_pantsbuild:IndentationPlugin"
+PB2 = "flake8_pantsbuild:TrailingWhitespacePlugin"
 PB6 = "flake8_pantsbuild:SixPlugin"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Originally, this also implemented PB200 for trailing whitespace detection, but it turns out this lint was identical to Flake8's. I had thought that PB200 was more permissive with allowing trailing whitespace in comments, but Flake8 allows it too.