### PR TITLE
Reshuffle error code numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,22 @@ If using without Pants, run `flake8 file.py` [as usual](http://flake8.pycqa.org/
 
 | Error code | Description                                                     | Notes                |
 |:----------:|:---------------------------------------------------------------:|:--------------------:|
-| PB100      | Check for 2-space indentation                                   | Disabled by default¹ |
-| PB201      | Using slashes instead of parentheses for line continuation      | Disabled by default² |
-| PB601      | Using old style `except` statements instead of the `as` keyword | Disabled by default³ |
-| PB602      | Using `iteritems`, `iterkeys`, or `itervalues`                  | Disabled by default³ |
-| PB603      | Using `xrange`                                                  | Disabled by default³ |
-| PB604      | Using `basestring` or `unicode`                                 | Disabled by default³ |
-| PB605      | Using metaclasses incompatible with Python 3                    | Disabled by default³ |
-| PB606      | Found Python 2 old-style classes (not inheriting `object`)      | Disabled by default³ |
-| PB607      | Using print statements, rather than print functions             | Disabled by default³ |
-| PB800      | Used class attribute that breaks inheritance                    |                      |
-| PB802      | Using `open` without a `with` statement (context manager)       |                      |
-| PB804      | Using a constant on the left-hand side of a logical operator    |                      |
-| PB805      | Using a constant on the right-hand side of an and operator      |                      |
+| PB10       | Used class attribute that breaks inheritance                    |                      |
+| PB11       | Using a constant on the left-hand side of a logical operator    |                      |
+| PB12       | Using a constant on the right-hand side of an and operator      |                      |
+| PB13       | Using `open` without a `with` statement (context manager)       |                      |
+| PB20       | Check for 2-space indentation                                   | Disabled by default¹ |
+| PB30       | Using slashes instead of parentheses for line continuation      | Disabled by default² |
+| PB60       | Using print statements, rather than print functions             | Disabled by default³ |
+| PB61       | Using old style `except` statements instead of the `as` keyword | Disabled by default³ |
+| PB62       | Using `iteritems`, `iterkeys`, or `itervalues`                  | Disabled by default³ |
+| PB63       | Using `xrange`                                                  | Disabled by default³ |
+| PB64       | Using `basestring` or `unicode`                                 | Disabled by default³ |
+| PB65       | Using metaclasses incompatible with Python 3                    | Disabled by default³ |
+| PB66       | Found Python 2 old-style classes (not inheriting `object`)      | Disabled by default³ |
 
-¹ To enable the `PB100` indentation lint, set `--enable-extensions=PB100`. You'll need to disable `E111` (check for 4-space indentation) via `--extend-ignore=E111`. You'll likely want to disable `E121`, `E124`, `E125`, `E127`, and `E128` as well.
-² To enable the `PB201` trailing slash lint, set `--enable-extensions=PB201`.
+¹ To enable the `PB20` indentation lint, set `--enable-extensions=PB20`. You'll need to disable `E111` (check for 4-space indentation) via `--extend-ignore=E111`. You'll likely want to disable `E121`, `E124`, `E125`, `E127`, and `E128` as well.
+² To enable the `PB30` trailing slash lint, set `--enable-extensions=PB30`.
 ³ To enable the `PB6*` checks for Python 2->3 lints, set `--enable-extensions=PB6`. 
 
 ## Migration from `pantsbuild.pants.contrib.python.checks.checker`

--- a/flake8_pantsbuild.py
+++ b/flake8_pantsbuild.py
@@ -17,48 +17,51 @@ else:
 
 PY2 = sys.version_info[0] < 3
 
-PB100 = "PB100 Indentation of {} instead of 2."
-PB201 = (
-    "PB201 Using a trailing slash (`\\`) instead of parentheses for line continuation. Refer "
+PB10 = (
+    "PB10 Instead of {name}.{attr} use self.{attr} or cls.{attr} with instance methods and "
+    "classmethods, respectively, so that inheritance works correctly."
+)
+PB11 = (
+    "PB11 Using a constant on the left-hand side of a logical operator. This means that the "
+    "left-hand side will always be truthy, so condition will short-circuit and the right-hand side "
+    "will never be evaluated."
+)
+PB12 = (
+    "PB12 Using a constant on the right-hand side of an `and` operator. This means that the "
+    "right-hand side will always be truthy, which is likely not expected."
+)
+PB13 = (
+    "PB13 `open()` calls should be made within a `with` statement (context manager). This is "
+    "important to ensure that the file handler is properly cleaned up."
+)
+
+PB20 = "PB20 Indentation of {} instead of 2."
+
+PB30 = (
+    "PB30 Using a trailing slash (`\\`) instead of parentheses for line continuation. Refer "
     "to https://www.tutorialspoint.com/How-to-wrap-long-lines-in-Python."
 )
-PB601 = (
-    "PB601 Using an old-style except statement. Instead of `except ValueError, e`, use "
+
+PB61 = (
+    "PB61 Using an old-style except statement. Instead of `except ValueError, e`, use "
     "`except ValueError as e`."
 )
-PB602 = (
-    "PB602 `{bad_attr}()` is removed in Python 3. Instead, use `{good_attr}()` or use "
+PB62 = (
+    "PB62 `{bad_attr}()` is removed in Python 3. Instead, use `{good_attr}()` or use "
     "`six.{bad_attr}()`."
 )
-PB603 = "PB603 `xrange()` is removed in Python 3. Instead, use `range()` or use `six.range()`."
-PB604 = "PB604 {bad_name} is removed in Python 3. Instead, use `six.{six_replacement}`."
-PB605 = (
-    "PB605 Using the old style of declaring metaclasses, which won't work properly with Python 3. "
+PB63 = "PB63 `xrange()` is removed in Python 3. Instead, use `range()` or use `six.range()`."
+PB64 = "PB64 {bad_name} is removed in Python 3. Instead, use `six.{six_replacement}`."
+PB65 = (
+    "PB65 Using the old style of declaring metaclasses, which won't work properly with Python 3. "
     "If you need to support both Python 2 and Python 3, use either `with_metaclass` or "
     "`add_metaclass` from `six` or `future`. If you don't care about Python 2 support, use "
     "`class Example(metaclass=MyMetaclass)`."
 )
-PB606 = "PB606 Classes must be new-style classes, meaning they inherit `object` or another class."
-PB607 = (
-    "PB607 Print used as a statement. Please either use `from __future__ import print_function` or "
+PB66 = "PB66 Classes must be new-style classes, meaning they inherit `object` or another class."
+PB60 = (
+    "PB60 Print used as a statement. Please either use `from __future__ import print_function` or "
     "rewrite to look like a function call, e.g. change `print 'hello'` to `print('hello')`."
-)
-PB800 = (
-    "PB800 Instead of {name}.{attr} use self.{attr} or cls.{attr} with instance methods and "
-    "classmethods, respectively, so that inheritance works correctly."
-)
-PB802 = (
-    "PB802 `open()` calls should be made within a `with` statement (context manager). This is "
-    "important to ensure that the file handler is properly cleaned up."
-)
-PB804 = (
-    "PB804 Using a constant on the left-hand side of a logical operator. This means that the "
-    "left-hand side will always be truthy, so condition will short-circuit and the right-hand side "
-    "will never be evaluated."
-)
-PB805 = (
-    "PB805 Using a constant on the right-hand side of an `and` operator. This means that the "
-    "right-hand side will always be truthy, which is likely not expected."
 )
 
 
@@ -75,16 +78,16 @@ class Visitor(ast.NodeVisitor):
         def plugin_enabled(codes):
             return any(code in options.enable_extensions for code in codes)
 
-        self.six_plugin_enabled = plugin_enabled(["PB6", "PB60"])
-        if plugin_enabled(["PB1", "PB10", "PB100"]):
-            self.check_for_pb100(tokens)
-        if plugin_enabled(["PB2", "PB20", "PB201"]):
-            self.check_for_pb201(lines=lines, tokens=tokens)
+        self.six_plugin_enabled = plugin_enabled(["PB6"])
+        if plugin_enabled(["PB2", "PB20"]):
+            self.check_for_pb20(tokens)
+        if plugin_enabled(["PB3", "PB30"]):
+            self.check_for_pb30(lines=lines, tokens=tokens)
 
     def collect_call_exprs_from_with_node(self, with_node):
         """Save any functions within a `with` statement to `self.with_call_exprs`.
 
-        This is needed for checking PB802.
+        This is needed for checking PB13.
         """
         if PY2:
             expr = with_node.context_expr
@@ -97,7 +100,50 @@ class Visitor(ast.NodeVisitor):
             }
         self.with_call_exprs.update(with_context_exprs)
 
-    def check_for_pb100(self, tokens):
+    def check_for_pb10(self, class_def_node):
+        for node in ast.walk(class_def_node):
+            is_class_attribute = isinstance(node, ast.Attribute) and isinstance(
+                node.value, ast.Name
+            )
+            if is_class_attribute and node.value.id == class_def_node.name:
+                self.errors.append(
+                    (
+                        node.value.lineno,
+                        node.value.col_offset,
+                        PB10.format(name=class_def_node.name, attr=node.attr),
+                    )
+                )
+
+    def check_for_pb11_and_pb12(self, bool_op_node):
+        def is_constant(expr):
+            if PY2:
+                is_name_constant = isinstance(expr, ast.Name) and expr.id in (
+                    "True",
+                    "False",
+                    "None",
+                )
+            else:
+                is_name_constant = isinstance(expr, ast.NameConstant)
+            return isinstance(expr, (ast.Num, ast.Str)) or is_name_constant
+
+        if not isinstance(bool_op_node.op, (ast.And, ast.Or)):
+            return
+        leftmost = bool_op_node.values[0]
+        rightmost = bool_op_node.values[-1]
+        if is_constant(leftmost):
+            self.errors.append((leftmost.lineno, leftmost.col_offset, PB11))
+        if isinstance(bool_op_node.op, ast.And) and is_constant(rightmost):
+            self.errors.append((rightmost.lineno, rightmost.col_offset, PB12))
+
+    def check_for_pb13(self, call_node):
+        if (
+            isinstance(call_node.func, ast.Name)
+            and call_node.func.id == "open"
+            and call_node not in self.with_call_exprs
+        ):
+            self.errors.append((call_node.lineno, call_node.col_offset, PB13))
+
+    def check_for_pb20(self, tokens):
         indents = []
         for token in tokens:
             token_type, token_text, token_start = token[0:3]
@@ -110,10 +156,10 @@ class Visitor(ast.NodeVisitor):
                 if current_indent - last_indent != 2:
                     lineno, col_offset = token_start
                     self.errors.append(
-                        (lineno, col_offset, PB100.format(current_indent - last_indent))
+                        (lineno, col_offset, PB20.format(current_indent - last_indent))
                     )
 
-    def check_for_pb201(self, lines, tokens):
+    def check_for_pb30(self, lines, tokens):
         lines = [line.rstrip("\n") for line in lines]
         # First generate a set of ranges where we accept trailing slashes, specifically within
         # comments and strings
@@ -146,17 +192,27 @@ class Visitor(ast.NodeVisitor):
             stripped_line = line.rstrip()
             col_offset = len(stripped_line) - 1
             if stripped_line.endswith("\\") and not has_exception(line_number, col_offset):
-                self.errors.append((line_number, col_offset, PB201))
+                self.errors.append((line_number, col_offset, PB30))
 
-    def check_for_pb601(self, try_except_node):
+    def check_for_pb60(self, print_node):
+        # This checks for a print statement being used _like_ a print function, e.g.
+        # `print("hello")`. It is still technically a print _statement_ rather than _function_, but
+        # it behaves the same as a print function.
+        logical_line = self.lines[print_node.lineno - 1]
+        print_offset = logical_line.index("print")
+        stripped_line = logical_line[print_offset + len("print") :]
+        if not self.PRINT_FUNCTION_REGEX.match(stripped_line):
+            self.errors.append((print_node.lineno, print_node.col_offset, PB60))
+
+    def check_for_pb61(self, try_except_node):
         for handler in try_except_node.handlers:
             logical_line = self.lines[handler.lineno - 1]
             except_offset = logical_line.index("except")
             stripped_line = logical_line[except_offset + len("except") :]
             if handler.name and " as " not in stripped_line:
-                self.errors.append((handler.lineno, handler.col_offset, PB601))
+                self.errors.append((handler.lineno, handler.col_offset, PB61))
 
-    def check_for_pb602_and_603(self, call_node):
+    def check_for_pb62_and_63(self, call_node):
         dict_iterators = {"iteritems": "items", "iterkeys": "keys", "itervalues": "values"}
         if isinstance(call_node.func, ast.Attribute):
             # Not a perfect solution since a user could have a dictionary named six or something
@@ -168,13 +224,13 @@ class Visitor(ast.NodeVisitor):
                     (
                         call_node.lineno,
                         call_node.col_offset,
-                        PB602.format(bad_attr=attr, good_attr=dict_iterators[attr]),
+                        PB62.format(bad_attr=attr, good_attr=dict_iterators[attr]),
                     )
                 )
         if isinstance(call_node.func, ast.Name) and call_node.func.id == "xrange":
-            self.errors.append((call_node.lineno, call_node.col_offset, PB603))
+            self.errors.append((call_node.lineno, call_node.col_offset, PB63))
 
-    def check_for_pb604(self, name_node):
+    def check_for_pb64(self, name_node):
         bad_names = {"basestring": "string_types", "unicode": "text_type"}
         name = name_node.id
         if name in bad_names:
@@ -182,11 +238,11 @@ class Visitor(ast.NodeVisitor):
                 (
                     name_node.lineno,
                     name_node.col_offset,
-                    PB604.format(bad_name=name, six_replacement=bad_names[name]),
+                    PB64.format(bad_name=name, six_replacement=bad_names[name]),
                 )
             )
 
-    def check_for_pb605(self, class_def_node):
+    def check_for_pb65(self, class_def_node):
         for node in class_def_node.body:
             if not isinstance(node, ast.Assign):
                 continue
@@ -194,95 +250,42 @@ class Visitor(ast.NodeVisitor):
                 if not isinstance(name, ast.Name):
                     continue
                 if name.id == "__metaclass__":
-                    self.errors.append((name.lineno, name.col_offset, PB605))
+                    self.errors.append((name.lineno, name.col_offset, PB65))
 
-    def check_for_pb606(self, class_def_node):
+    def check_for_pb66(self, class_def_node):
         if not class_def_node.bases:
-            self.errors.append((class_def_node.lineno, class_def_node.col_offset, PB606))
-
-    def check_for_pb607(self, print_node):
-        # This checks for a print statement being used _like_ a print function, e.g.
-        # `print("hello")`. It is still technically a print _statement_ rather than _function_, but
-        # it behaves the same as a print function.
-        logical_line = self.lines[print_node.lineno - 1]
-        print_offset = logical_line.index("print")
-        stripped_line = logical_line[print_offset + len("print") :]
-        if not self.PRINT_FUNCTION_REGEX.match(stripped_line):
-            self.errors.append((print_node.lineno, print_node.col_offset, PB607))
-
-    def check_for_pb800(self, class_def_node):
-        for node in ast.walk(class_def_node):
-            is_class_attribute = isinstance(node, ast.Attribute) and isinstance(
-                node.value, ast.Name
-            )
-            if is_class_attribute and node.value.id == class_def_node.name:
-                self.errors.append(
-                    (
-                        node.value.lineno,
-                        node.value.col_offset,
-                        PB800.format(name=class_def_node.name, attr=node.attr),
-                    )
-                )
-
-    def check_for_pb802(self, call_node):
-        if (
-            isinstance(call_node.func, ast.Name)
-            and call_node.func.id == "open"
-            and call_node not in self.with_call_exprs
-        ):
-            self.errors.append((call_node.lineno, call_node.col_offset, PB802))
-
-    def check_for_pb804_and_pb805(self, bool_op_node):
-        def is_constant(expr):
-            if PY2:
-                is_name_constant = isinstance(expr, ast.Name) and expr.id in (
-                    "True",
-                    "False",
-                    "None",
-                )
-            else:
-                is_name_constant = isinstance(expr, ast.NameConstant)
-            return isinstance(expr, (ast.Num, ast.Str)) or is_name_constant
-
-        if not isinstance(bool_op_node.op, (ast.And, ast.Or)):
-            return
-        leftmost = bool_op_node.values[0]
-        rightmost = bool_op_node.values[-1]
-        if is_constant(leftmost):
-            self.errors.append((leftmost.lineno, leftmost.col_offset, PB804))
-        if isinstance(bool_op_node.op, ast.And) and is_constant(rightmost):
-            self.errors.append((rightmost.lineno, rightmost.col_offset, PB805))
+            self.errors.append((class_def_node.lineno, class_def_node.col_offset, PB66))
 
     def visit_BoolOp(self, bool_op_node):
-        self.check_for_pb804_and_pb805(bool_op_node)
+        self.check_for_pb11_and_pb12(bool_op_node)
         self.generic_visit(bool_op_node)
 
     def visit_Call(self, call_node):
         if self.six_plugin_enabled:
-            self.check_for_pb602_and_603(call_node)
-        self.check_for_pb802(call_node)
+            self.check_for_pb62_and_63(call_node)
+        self.check_for_pb13(call_node)
         self.generic_visit(call_node)
 
     def visit_ClassDef(self, class_def_node):
         if self.six_plugin_enabled:
-            self.check_for_pb605(class_def_node)
-            self.check_for_pb606(class_def_node)
-        self.check_for_pb800(class_def_node)
+            self.check_for_pb65(class_def_node)
+            self.check_for_pb66(class_def_node)
+        self.check_for_pb10(class_def_node)
         self.generic_visit(class_def_node)
 
     def visit_Name(self, name_node):
         if self.six_plugin_enabled:
-            self.check_for_pb604(name_node)
+            self.check_for_pb64(name_node)
         self.generic_visit(name_node)
 
     def visit_Print(self, print_node):
         if self.six_plugin_enabled:
-            self.check_for_pb607(print_node)
+            self.check_for_pb60(print_node)
         self.generic_visit(print_node)
 
     def visit_TryExcept(self, try_except_node):
         if self.six_plugin_enabled:
-            self.check_for_pb601(try_except_node)
+            self.check_for_pb61(try_except_node)
         self.generic_visit(try_except_node)
 
     def visit_With(self, with_node):
@@ -307,12 +310,6 @@ class Plugin(object):
             yield line, col, msg, type(self)
 
 
-class SixPlugin(Plugin):
-    """Several lints to help with Python 2->3 migrations."""
-
-    off_by_default = True
-
-
 class IndentationPlugin(Plugin):
     """Lint for 2-space indentation.
 
@@ -329,5 +326,11 @@ class TrailingSlashesPlugin(Plugin):
     Flake8 does not automatically check for trailing slashes, but this is a subjective style
     preference so should be disabled by default.
     """
+
+    off_by_default = True
+
+
+class SixPlugin(Plugin):
+    """Several lints to help with Python 2->3 migrations."""
 
     off_by_default = True

--- a/flake8_pantsbuild_test.py
+++ b/flake8_pantsbuild_test.py
@@ -10,19 +10,19 @@ from textwrap import dedent
 import pytest
 
 from flake8_pantsbuild import (
-    PB100,
-    PB201,
-    PB601,
-    PB602,
-    PB603,
-    PB604,
-    PB605,
-    PB606,
-    PB607,
-    PB800,
-    PB802,
-    PB804,
-    PB805,
+    PB10,
+    PB11,
+    PB12,
+    PB13,
+    PB20,
+    PB30,
+    PB60,
+    PB61,
+    PB62,
+    PB63,
+    PB64,
+    PB65,
+    PB66,
     PY2,
 )
 
@@ -32,7 +32,70 @@ from flake8_pantsbuild import (
 # a set in every test for deduplication. See https://pypi.org/project/pytest-flake8dir/.
 
 
-def test_pb_100(flake8dir):
+def test_pb_10(flake8dir):
+    template = dedent(
+        """\
+        import os.path
+
+
+        class Example(object):
+            CONSTANT = "foo"
+
+            def foo(self, value):
+                return os.path.join({}.CONSTANT, value)
+        """
+    )
+    flake8dir.make_py_files(good=template.format("self"), bad=template.format("Example"))
+    result = flake8dir.run_flake8()
+    assert {"./bad.py:8:29: {}".format(PB10.format(name="Example", attr="CONSTANT"))} == set(
+        result.out_lines
+    )
+
+
+def test_pb_11(flake8dir):
+    violating_pairs = itertools.product([None, False, True, 1, "'a'"], ["or", "and"])
+    violations = {
+        "bad{}".format(i): "x = 0\n{constant} {op} x".format(constant=pair[0], op=pair[1])
+        for i, pair in enumerate(violating_pairs)
+    }
+    flake8dir.make_py_files(good="x = y = 0\nx or y", **violations)
+    result = flake8dir.run_flake8()
+    assert {"./{}.py:2:1: {}".format(fp, PB11) for fp in violations} == set(result.out_lines)
+
+
+def test_pb_12(flake8dir):
+    violations = {
+        "bad{}".format(i): "x = 0\nx and {}".format(constant)
+        for i, constant in enumerate([None, False, True, 1, "'a'"])
+    }
+    flake8dir.make_py_files(good="x = y = 0\nx and y", **violations)
+    result = flake8dir.run_flake8()
+    assert {"./{}.py:2:7: {}".format(fp, PB12) for fp in violations} == set(result.out_lines)
+
+
+def test_pb_13(flake8dir):
+    flake8dir.make_example_py(
+        dedent(
+            """\
+            foo = open('test.txt')
+
+            with open('test.txt'):
+                pass
+
+            bar = open('test.txt')
+
+            with open('test.txt') as fp:
+                fp.read()
+            """
+        )
+    )
+    result = flake8dir.run_flake8()
+    assert {"./example.py:1:7: {}".format(PB13), "./example.py:6:7: {}".format(PB13)} == set(
+        result.out_lines
+    )
+
+
+def test_pb_20(flake8dir):
     flake8dir.make_example_py(
         dedent(
             """\
@@ -57,15 +120,15 @@ def test_pb_100(flake8dir):
         )
     )
     result = flake8dir.run_flake8(
-        extra_args=["--enable-extensions", "PB100", "--extend-ignore", "E111"]
+        extra_args=["--enable-extensions", "PB20", "--extend-ignore", "E111"]
     )
     assert {
-        "./example.py:2:1: {}".format(PB100.format("1")),
-        "./example.py:6:1: {}".format(PB100.format("4")),
+        "./example.py:2:1: {}".format(PB20.format("1")),
+        "./example.py:6:1: {}".format(PB20.format("4")),
     } == set(result.out_lines)
 
 
-def test_pb_201(flake8dir):
+def test_pb_30(flake8dir):
     flake8dir.make_example_py(
         dedent(
             """\
@@ -93,14 +156,43 @@ def test_pb_201(flake8dir):
             """
         )
     )
-    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB201"])
-    assert {"./example.py:3:7: {}".format(PB201), "./example.py:6:20: {}".format(PB201)} == set(
+    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB30"])
+    assert {"./example.py:3:7: {}".format(PB30), "./example.py:6:20: {}".format(PB30)} == set(
+        result.out_lines
+    )
+
+
+@pytest.mark.skipif(not PY2, reason="Print statements cause syntax errors with Python 3")
+def test_pb_60(flake8dir):
+    flake8dir.make_py_files(
+        normal=dedent(
+            """\
+            # Good
+            print("I'm a statement, but look like a function call")
+            print(0, 1, 2)
+            print (0, 1, 2)
+
+            # Bad
+            print "old school"
+            print 0
+            """
+        ),
+        future=dedent(
+            """\
+            from __future__ import print_function
+
+            print("Future-proof!")
+            """
+        ),
+    )
+    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
+    assert {"./normal.py:7:1: {}".format(PB60), "./normal.py:8:1: {}".format(PB60)} == set(
         result.out_lines
     )
 
 
 @pytest.mark.skipif(not PY2, reason="Old-style exceptions cause syntax error with Python 3")
-def test_pb_601(flake8dir):
+def test_pb_61(flake8dir):
     flake8dir.make_example_py(
         dedent(
             """\
@@ -132,12 +224,12 @@ def test_pb_601(flake8dir):
         )
     )
     result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
-    assert {"./example.py:3:1: {}".format(PB601), "./example.py:8:1: {}".format(PB601)} == set(
+    assert {"./example.py:3:1: {}".format(PB61), "./example.py:8:1: {}".format(PB61)} == set(
         result.out_lines
     )
 
 
-def test_pb_602(flake8dir):
+def test_pb_62(flake8dir):
     flake8dir.make_example_py(
         dedent(
             """\
@@ -167,15 +259,15 @@ def test_pb_602(flake8dir):
     )
     result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
     assert {
-        "./example.py:7:1: {}".format(PB602.format(bad_attr="iteritems", good_attr="items")),
-        "./example.py:8:1: {}".format(PB602.format(bad_attr="iterkeys", good_attr="keys")),
-        "./example.py:9:1: {}".format(PB602.format(bad_attr="itervalues", good_attr="values")),
-        "./example.py:21:1: {}".format(PB602.format(bad_attr="iteritems", good_attr="items")),
+        "./example.py:7:1: {}".format(PB62.format(bad_attr="iteritems", good_attr="items")),
+        "./example.py:8:1: {}".format(PB62.format(bad_attr="iterkeys", good_attr="keys")),
+        "./example.py:9:1: {}".format(PB62.format(bad_attr="itervalues", good_attr="values")),
+        "./example.py:21:1: {}".format(PB62.format(bad_attr="iteritems", good_attr="items")),
     } == set(result.out_lines)
 
 
 @pytest.mark.skipif(not PY2, reason="`xrange()` does not exist in Python 3`")
-def test_pb_603(flake8dir):
+def test_pb_63(flake8dir):
     flake8dir.make_example_py(
         dedent(
             """\
@@ -193,11 +285,11 @@ def test_pb_603(flake8dir):
         )
     )
     result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
-    assert {"./example.py:4:1: {}".format(PB603)} == set(result.out_lines)
+    assert {"./example.py:4:1: {}".format(PB63)} == set(result.out_lines)
 
 
 @pytest.mark.skipif(not PY2, reason="`basestring` and `unicode` do not exist in Python 3`")
-def test_pb_604(flake8dir):
+def test_pb_64(flake8dir):
     flake8dir.make_example_py(
         dedent(
             """\
@@ -209,15 +301,15 @@ def test_pb_604(flake8dir):
     result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
     assert {
         "./example.py:1:26: {}".format(
-            PB604.format(bad_name="unicode", six_replacement="text_type")
+            PB64.format(bad_name="unicode", six_replacement="text_type")
         ),
         "./example.py:2:26: {}".format(
-            PB604.format(bad_name="basestring", six_replacement="string_types")
+            PB64.format(bad_name="basestring", six_replacement="string_types")
         ),
     } == set(result.out_lines)
 
 
-def test_pb_605(flake8dir):
+def test_pb_65(flake8dir):
     flake8dir.make_example_py(
         dedent(
             """\
@@ -240,10 +332,10 @@ def test_pb_605(flake8dir):
         )
     )
     result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
-    assert {"./example.py:6:5: {}".format(PB605)} == set(result.out_lines)
+    assert {"./example.py:6:5: {}".format(PB65)} == set(result.out_lines)
 
 
-def test_pb_606(flake8dir):
+def test_pb_66(flake8dir):
     flake8dir.make_example_py(
         dedent(
             """\
@@ -268,98 +360,6 @@ def test_pb_606(flake8dir):
         )
     )
     result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
-    assert {"./example.py:4:1: {}".format(PB606), "./example.py:16:1: {}".format(PB606)} == set(
+    assert {"./example.py:4:1: {}".format(PB66), "./example.py:16:1: {}".format(PB66)} == set(
         result.out_lines
     )
-
-
-@pytest.mark.skipif(not PY2, reason="Print statements cause syntax errors with Python 3")
-def test_pb_607(flake8dir):
-    flake8dir.make_py_files(
-        normal=dedent(
-            """\
-            # Good
-            print("I'm a statement, but look like a function call")
-            print(0, 1, 2)
-            print (0, 1, 2)
-
-            # Bad
-            print "old school"
-            print 0
-            """
-        ),
-        future=dedent(
-            """\
-            from __future__ import print_function
-
-            print("Future-proof!")
-            """
-        ),
-    )
-    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
-    assert {"./normal.py:7:1: {}".format(PB607), "./normal.py:8:1: {}".format(PB607)} == set(
-        result.out_lines
-    )
-
-
-def test_pb_800(flake8dir):
-    template = dedent(
-        """\
-        import os.path
-
-
-        class Example(object):
-            CONSTANT = "foo"
-
-            def foo(self, value):
-                return os.path.join({}.CONSTANT, value)
-        """
-    )
-    flake8dir.make_py_files(good=template.format("self"), bad=template.format("Example"))
-    result = flake8dir.run_flake8()
-    assert {"./bad.py:8:29: {}".format(PB800.format(name="Example", attr="CONSTANT"))} == set(
-        result.out_lines
-    )
-
-
-def test_pb_802(flake8dir):
-    flake8dir.make_example_py(
-        dedent(
-            """\
-            foo = open('test.txt')
-
-            with open('test.txt'):
-                pass
-
-            bar = open('test.txt')
-
-            with open('test.txt') as fp:
-                fp.read()
-            """
-        )
-    )
-    result = flake8dir.run_flake8()
-    assert {"./example.py:1:7: {}".format(PB802), "./example.py:6:7: {}".format(PB802)} == set(
-        result.out_lines
-    )
-
-
-def test_pb_804(flake8dir):
-    violating_pairs = itertools.product([None, False, True, 1, "'a'"], ["or", "and"])
-    violations = {
-        "bad{}".format(i): "x = 0\n{constant} {op} x".format(constant=pair[0], op=pair[1])
-        for i, pair in enumerate(violating_pairs)
-    }
-    flake8dir.make_py_files(good="x = y = 0\nx or y", **violations)
-    result = flake8dir.run_flake8()
-    assert {"./{}.py:2:1: {}".format(fp, PB804) for fp in violations} == set(result.out_lines)
-
-
-def test_pb_805(flake8dir):
-    violations = {
-        "bad{}".format(i): "x = 0\nx and {}".format(constant)
-        for i, constant in enumerate([None, False, True, 1, "'a'"])
-    }
-    flake8dir.make_py_files(good="x = y = 0\nx and y", **violations)
-    result = flake8dir.run_flake8()
-    assert {"./{}.py:2:7: {}".format(fp, PB805) for fp in violations} == set(result.out_lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ authors = ["Pantsbuild developers <pantsbuild@gmail.com>"]
 license = "Apache-2.0"
 
 [tool.poetry.plugins."flake8.extension"]
-PB8 = "flake8_pantsbuild:Plugin"
-PB100 = "flake8_pantsbuild:IndentationPlugin"
-PB201 = "flake8_pantsbuild:TrailingSlashesPlugin"
+PB1 = "flake8_pantsbuild:Plugin"
+PB2 = "flake8_pantsbuild:IndentationPlugin"
+PB3 = "flake8_pantsbuild:TrailingSlashesPlugin"
 PB6 = "flake8_pantsbuild:SixPlugin"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Flake8 only requires that codes have at least 3 characters, so we could use codes like `PB1`, `PB2`, etc. We go with two-digit numbers to allow more lints than 10. This is much easier to reason with than 3-digits, e.g. `PB20 vs. PB200`.

We use this scheme:

`1*` -> logical issues
`20` -> 2-space indentation
`30` -> trailing slashes
`6*` -> Py2 to Py3 lints (2 x 3 = 6)