### PR TITLE
Drop support for Python 2 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ jobs:
   include:
     - name: Format check
       script: tox -e format-check
-    - name: Python 2.7
-      python: "2.7"
-      script: tox -e py27
-    - name: Python 3.5
-      python: "3.5"
-      script: tox -e py35
     - name: Python 3.6
       python: "3.6"
       script: tox -e py36

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ $ pip install flake8-pantsbuild
 
 ### Supported Python versions
 
-This plugin works with Python 2.7 and 3.5+.
+This plugin works with Python 3.6+.
+
+If you need support for Python 2.7 or Python 3.5, install `flake8-pantsbuild==1.*` and refer to the README at https://github.com/pantsbuild/flake8-pantsbuild/blob/1.x/README.md.
 
 ## Usage
 
@@ -52,19 +54,10 @@ If using without Pants, run `flake8 file.py` [as usual](http://flake8.pycqa.org/
 | PB13       | Using `open` without a `with` statement (context manager)       |                      |
 | PB20       | Check for 2-space indentation                                   | Disabled by default¹ |
 | PB30       | Using slashes instead of parentheses for line continuation      | Disabled by default² |
-| PB60       | Using `print` statements, rather than the `print` function      | Disabled by default³ |
-| PB61       | Using old style `except` statements instead of the `as` keyword | Disabled by default³ |
-| PB62       | Using `iteritems`, `iterkeys`, or `itervalues`                  | Disabled by default³ |
-| PB63       | Using `xrange`                                                  | Disabled by default³ |
-| PB64       | Using `basestring` or `unicode`                                 | Disabled by default³ |
-| PB65       | Using metaclasses incompatible with Python 3                    | Disabled by default³ |
-| PB66       | Using Python 2 old-style classes (not inheriting `object`)      | Disabled by default³ |
 
 ¹ To enable the `PB20` indentation lint, set `--enable-extensions=PB20`. You'll need to disable `E111` (check for 4-space indentation) via `--extend-ignore=E111`. You'll likely want to disable `E121`, `E124`, `E125`, `E127`, and `E128` as well.
 
 ² To enable the `PB30` trailing slash lint, set `--enable-extensions=PB30`.
-
-³ To enable the `PB6*` checks for Python 2->3 lints, set `--enable-extensions=PB6`. 
 
 ## Migrating from `lint.pythonstyle` to `flake8`
 
@@ -122,13 +115,13 @@ extra_requirements.add = [
 | T404     | pycheck-import-order        | Unclassifiable import                                           | `isort` or `flake8-import-order` plugin ² |
 | T405     | pycheck-import-order        | Import block has multiple module types                          | `isort` or `flake8-import-order` plugin ² |
 | T406     | pycheck-import-orde         | Out of order import statements                                  | `isort` or `flake8-import-order` plugin ² |
-| T601     | pycheck-except-statement    | Using old style `except` statements instead of the `as` keyword | `PB61`¹                                   |
-| T602     | pycheck-future-compat       | Using `iteritems`, `iterkeys`, or `itervalues`                  | `PB62`¹                                   |
-| T603     | pycheck-future-compat       | Using `xrange`                                                  | `PB63`¹                                   |
-| T604     | pycheck-future-compat       | Using `basestring` or `unicode`                                 | `PB64`¹                                   |
-| T605     | pycheck-future-compat       | Using metaclasses incompatible with Python 3                    | `PB65`¹                                   |
-| T606     | pycheck-new-style-classes   | Found Python 2 old-style classes (not inheriting `object`)      | `PB66`¹                                   |
-| T607     | pycheck-print-statements    | Using `print` statements, rather than the `print` function      | `PB60`¹                                   |
+| T601     | pycheck-except-statement    | Using old style `except` statements instead of the `as` keyword | `PB61`³                                   |
+| T602     | pycheck-future-compat       | Using `iteritems`, `iterkeys`, or `itervalues`                  | `PB62`³                                   |
+| T603     | pycheck-future-compat       | Using `xrange`                                                  | `PB63`³                                   |
+| T604     | pycheck-future-compat       | Using `basestring` or `unicode`                                 | `PB64`³                                   |
+| T605     | pycheck-future-compat       | Using metaclasses incompatible with Python 3                    | `PB65`³                                   |
+| T606     | pycheck-new-style-classes   | Found Python 2 old-style classes (not inheriting `object`)      | `PB66`³                                   |
+| T607     | pycheck-print-statements    | Using `print` statements, rather than the `print` function      | `PB60`³                                   |
 | T800     | pycheck-class-factoring     | Using class attribute that breaks inheritance                   | `PB10`                                    |
 | T801     | pycheck-variable-names      | Shadowing a `builtin` name                                      | `flake8-builtins` plugin                  |
 | T802     | pycheck-context-manager     | Using `open` without a `with` statement (context manager)       | `PB13`                                    |
@@ -139,6 +132,8 @@ extra_requirements.add = [
 ¹ This lint is disabled by default. See the above section [`Error Codes`](#error-codes) for instructions on how to enable this lint.
 
 ² To use `isort` with Pants, set `backend_packages2.add = ["pants.backend.python.lint.isort"]` in your `pants.toml`.
+
+³ The `PB6*` lints are only available in the `1.x` release series for this plugin because `2.x` drops support for Python 2. Please refer to the README at https://github.com/pantsbuild/flake8-pantsbuild/blob/1.x/README.md#error-codes for instructions on how to use this plugin.
 
 ## Development
 
@@ -152,7 +147,6 @@ You may run certain environments with `tox -e` (run `tox -a` to see all options)
 
 ```bash
 $ tox -e format-run
-$ tox -e py27
 $ tox -e py36
 ```
 

--- a/flake8_pantsbuild_test.py
+++ b/flake8_pantsbuild_test.py
@@ -1,35 +1,10 @@
-# -*- coding: utf-8 -*-
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 import itertools
 from textwrap import dedent
 
-import pytest
-
-from flake8_pantsbuild import (
-    PB10,
-    PB11,
-    PB12,
-    PB13,
-    PB20,
-    PB30,
-    PB60,
-    PB61,
-    PB62,
-    PB63,
-    PB64,
-    PB65,
-    PB66,
-    PY2,
-)
-
-# NB: `pytest-flake8dir` has a known issue that it runs our plugin twice for every test. This means
-# that result.out will have the same error twice for every file. This was fixed in 2.1.0, but we
-# can't upgrade past 1.3.0 due to needing to support Python 2. So, we convert result.out_lines to
-# a set in every test for deduplication. See https://pypi.org/project/pytest-flake8dir/.
+from flake8_pantsbuild import PB10, PB11, PB12, PB13, PB20, PB30
 
 
 def test_pb_10(flake8dir):
@@ -38,7 +13,7 @@ def test_pb_10(flake8dir):
         import os.path
 
 
-        class Example(object):
+        class Example:
             CONSTANT = "foo"
 
             def foo(self, value):
@@ -47,30 +22,27 @@ def test_pb_10(flake8dir):
     )
     flake8dir.make_py_files(good=template.format("self"), bad=template.format("Example"))
     result = flake8dir.run_flake8()
-    assert {"./bad.py:8:29: {}".format(PB10.format(name="Example", attr="CONSTANT"))} == set(
-        result.out_lines
-    )
+    assert [f"./bad.py:8:29: {PB10.format(name='Example', attr='CONSTANT')}"] == result.out_lines
 
 
 def test_pb_11(flake8dir):
     violating_pairs = itertools.product([None, False, True, 1, "'a'"], ["or", "and"])
     violations = {
-        "bad{}".format(i): "x = 0\n{constant} {op} x".format(constant=pair[0], op=pair[1])
-        for i, pair in enumerate(violating_pairs)
+        f"bad{i}": f"x = 0\n{pair[0]} {pair[1]} x" for i, pair in enumerate(violating_pairs)
     }
     flake8dir.make_py_files(good="x = y = 0\nx or y", **violations)
     result = flake8dir.run_flake8()
-    assert {"./{}.py:2:1: {}".format(fp, PB11) for fp in violations} == set(result.out_lines)
+    assert sorted(f"./{fp}.py:2:1: {PB11}" for fp in violations) == sorted(result.out_lines)
 
 
 def test_pb_12(flake8dir):
     violations = {
-        "bad{}".format(i): "x = 0\nx and {}".format(constant)
+        f"bad{i}": f"x = 0\nx and {constant}"
         for i, constant in enumerate([None, False, True, 1, "'a'"])
     }
     flake8dir.make_py_files(good="x = y = 0\nx and y", **violations)
     result = flake8dir.run_flake8()
-    assert {"./{}.py:2:7: {}".format(fp, PB12) for fp in violations} == set(result.out_lines)
+    assert sorted(f"./{fp}.py:2:7: {PB12}" for fp in violations) == sorted(result.out_lines)
 
 
 def test_pb_13(flake8dir):
@@ -90,9 +62,7 @@ def test_pb_13(flake8dir):
         )
     )
     result = flake8dir.run_flake8()
-    assert {"./example.py:1:7: {}".format(PB13), "./example.py:6:7: {}".format(PB13)} == set(
-        result.out_lines
-    )
+    assert [f"./example.py:1:7: {PB13}", f"./example.py:6:7: {PB13}"] == result.out_lines
 
 
 def test_pb_20(flake8dir):
@@ -122,10 +92,10 @@ def test_pb_20(flake8dir):
     result = flake8dir.run_flake8(
         extra_args=["--enable-extensions", "PB20", "--extend-ignore", "E111"]
     )
-    assert {
-        "./example.py:2:1: {}".format(PB20.format("1")),
-        "./example.py:6:1: {}".format(PB20.format("4")),
-    } == set(result.out_lines)
+    assert [
+        f"./example.py:2:1: {PB20.format('1')}",
+        f"./example.py:6:1: {PB20.format('4')}",
+    ] == result.out_lines
 
 
 def test_pb_30(flake8dir):
@@ -157,209 +127,4 @@ def test_pb_30(flake8dir):
         )
     )
     result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB30"])
-    assert {"./example.py:3:7: {}".format(PB30), "./example.py:6:20: {}".format(PB30)} == set(
-        result.out_lines
-    )
-
-
-@pytest.mark.skipif(not PY2, reason="Print statements cause syntax errors with Python 3")
-def test_pb_60(flake8dir):
-    flake8dir.make_py_files(
-        normal=dedent(
-            """\
-            # Good
-            print("I'm a statement, but look like a function call")
-            print(0, 1, 2)
-            print (0, 1, 2)
-
-            # Bad
-            print "old school"
-            print 0
-            """
-        ),
-        future=dedent(
-            """\
-            from __future__ import print_function
-
-            print("Future-proof!")
-            """
-        ),
-    )
-    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
-    assert {"./normal.py:7:1: {}".format(PB60), "./normal.py:8:1: {}".format(PB60)} == set(
-        result.out_lines
-    )
-
-
-@pytest.mark.skipif(not PY2, reason="Old-style exceptions cause syntax error with Python 3")
-def test_pb_61(flake8dir):
-    flake8dir.make_example_py(
-        dedent(
-            """\
-            try:
-                pass
-            except ValueError, e:
-                raise e
-
-            try:
-                pass
-            except (ValueError, TypeError), e:
-                raise e
-
-            try:
-                pass
-            except ValueError:
-                raise
-
-            try:
-                pass
-            except ValueError as e:
-                raise e
-
-            try:
-                pass
-            except (ValueError, TypeError) as e:
-                raise e
-            """
-        )
-    )
-    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
-    assert {"./example.py:3:1: {}".format(PB61), "./example.py:8:1: {}".format(PB61)} == set(
-        result.out_lines
-    )
-
-
-def test_pb_62(flake8dir):
-    flake8dir.make_example_py(
-        dedent(
-            """\
-            import six
-            from six import iteritems
-
-            d1 = {"hello": 0}
-
-            # Bad
-            d1.iteritems()
-            d1.iterkeys()
-            d1.itervalues()
-
-            # Good
-            d1.items()
-            d1.keys()
-            d1.values()
-            six.iteritems()
-            iteritems(d1)
-
-            # We don't actually check that it's a dictionary. We only
-            # check for the method name.
-            o = object()
-            o.iteritems()
-            """
-        )
-    )
-    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
-    assert {
-        "./example.py:7:1: {}".format(PB62.format(bad_attr="iteritems", good_attr="items")),
-        "./example.py:8:1: {}".format(PB62.format(bad_attr="iterkeys", good_attr="keys")),
-        "./example.py:9:1: {}".format(PB62.format(bad_attr="itervalues", good_attr="values")),
-        "./example.py:21:1: {}".format(PB62.format(bad_attr="iteritems", good_attr="items")),
-    } == set(result.out_lines)
-
-
-@pytest.mark.skipif(not PY2, reason="`xrange()` does not exist in Python 3`")
-def test_pb_63(flake8dir):
-    flake8dir.make_example_py(
-        dedent(
-            """\
-            import six
-
-            # Bad
-            xrange(10)
-
-            # Good
-            range(10)
-            six.range()
-            o = object()
-            o.xrange()
-            """
-        )
-    )
-    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
-    assert {"./example.py:4:1: {}".format(PB63)} == set(result.out_lines)
-
-
-@pytest.mark.skipif(not PY2, reason="`basestring` and `unicode` do not exist in Python 3`")
-def test_pb_64(flake8dir):
-    flake8dir.make_example_py(
-        dedent(
-            """\
-            assert isinstance("txt", unicode)
-            assert isinstance("txt", basestring)
-            """
-        )
-    )
-    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
-    assert {
-        "./example.py:1:26: {}".format(
-            PB64.format(bad_name="unicode", six_replacement="text_type")
-        ),
-        "./example.py:2:26: {}".format(
-            PB64.format(bad_name="basestring", six_replacement="string_types")
-        ),
-    } == set(result.out_lines)
-
-
-def test_pb_65(flake8dir):
-    flake8dir.make_example_py(
-        dedent(
-            """\
-            from fake import SingletonMetaclass
-            from six import add_metaclass, with_metaclass
-
-
-            class Singleton(object):
-                __metaclass__ = SingletonMetaclass
-
-
-            @add_metaclass(SingletonMetaclass)
-            class SafeSingleton(object):
-                pass
-
-
-            class SafeSingleton2(with_metaclass(object, SingletonMetaclass)):
-                pass
-            """
-        )
-    )
-    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
-    assert {"./example.py:6:5: {}".format(PB65)} == set(result.out_lines)
-
-
-def test_pb_66(flake8dir):
-    flake8dir.make_example_py(
-        dedent(
-            """\
-            from fake import Super1, Super2
-
-
-            class OldStyle:
-                pass
-
-
-            class NewStyle(object):
-                pass
-
-
-            class Subclass(Super1, Super2):
-                pass
-
-
-            class NoMroSpecified():
-                pass
-            """
-        )
-    )
-    result = flake8dir.run_flake8(extra_args=["--enable-extensions", "PB6"])
-    assert {"./example.py:4:1: {}".format(PB66), "./example.py:16:1: {}".format(PB66)} == set(
-        result.out_lines
-    )
+    assert [f"./example.py:3:7: {PB30}", f"./example.py:6:20: {PB30}"] == result.out_lines

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,16 +20,15 @@ classifiers = [
 PB1 = "flake8_pantsbuild:Plugin"
 PB2 = "flake8_pantsbuild:IndentationPlugin"
 PB3 = "flake8_pantsbuild:TrailingSlashesPlugin"
-PB6 = "flake8_pantsbuild:SixPlugin"
 
 [tool.poetry.dependencies]
-python = ">=2.7,<3.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+python = ">=3.6"
 flake8 = ">=3.7"
 importlib_metadata = {version = ">=1.3.0", python = "<3.8"}
 
 [tool.black]
 line-length = 100
-target-version = ['py27']
+target-version = ['py36']
 
 [tool.isort]
 multi_line_output = 3

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 isolated_build = true
 minversion = 3.14.1
 skip_missing_interpreters = true
-envlist = format-check, py{27,35,36,37,38}
+envlist = format-check, py3{6,7,8}
 
 [tox:.package]
 # NB: tox will use the same python version as under what tox is installed to package, so unless
@@ -14,9 +14,8 @@ basepython = python3
 [testenv]
 deps =
     flake8
-    # NB: we can't use Pytest 5 or pytest-flakedir 2.* because these only support Python 3.
-    pytest==4.6.6
-    pytest-flake8dir==1.3.0
+    pytest
+    pytest-flake8dir
 commands =
     pytest -v {posargs}
     # NB: Flake8 results depend upon which Python version is used. We want it to run for every


### PR DESCRIPTION
Version 1.x of this library will always support Python 2 through the `1.x` branch https://github.com/pantsbuild/flake8-pantsbuild/tree/1.x, but the `master` branch has no need to keep support.

This allows us to greatly simplify the code and remove all of the `PB6*` lints. 