### PR TITLE
Prepare 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0 (03/15/2020)
+
+* Prepare 2.0.0 ([#22](https://github.com/pantsbuild/flake8-pantsbuild/pull/22))
+* Add type hints and MyPy ([#21](https://github.com/pantsbuild/flake8-pantsbuild/pull/21))
+* Drop support for Python 2 and 3.5 ([#20](https://github.com/pantsbuild/flake8-pantsbuild/pull/20))
+
 ## 1.0.0 (03/15/2020)
 
 * Prepare 1.0.0 ([#19](https://github.com/pantsbuild/flake8-pantsbuild/pull/19))

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,8 @@
 # Release Process
 
-
 ## Prerequisites
 
-* Install [`Poetry`](https://python-poetry.org/docs/)
+* Install [`Poetry`](https://python-poetry.org/docs/).
 * Set up PGP and PyPI. See https://www.pantsbuild.org/release.html#0-prerequisites.
 
 ## Preparation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "flake8-pantsbuild"
-version = "1.0.0"
+version = "2.0.0"
 description = "Various Flake8 lints used by the Pants project and its users."
 authors = ["Pantsbuild developers <pantsbuild@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This release drops support for Python 2.7 and 3.5. The 1.x branch will stay around to keep that support for users who need it.